### PR TITLE
added Source-Url to manifest.yml to obtain cartridge via URL

### DIFF
--- a/metadata/manifest.yml
+++ b/metadata/manifest.yml
@@ -8,6 +8,7 @@ License-Url: http://www.apache.org/licenses/LICENSE-2.0.txt
 Vendor: AeroGear
 Cartridge-Version: '1.0.3'
 Cartridge-Vendor: aerogear
+Source-Url: https://github.com/aerogear/openshift-origin-cartridge-aerogear-push/archive/master.zip
 Categories:
   - service
   - web_framework


### PR DESCRIPTION
@matzew @fjuma 

without this parameter, it is not possible to use direct path to manifest.yml as it is used here (1) so I can not reference the cartridge from command line to use directly this manifest.

```
Creating application 'quickstarts' ... The provided downloadable cartridge 
'https://raw.githubusercontent.com/aerogear/openshift-origin-cartridge-aerogear-push/master/metadata/manifest.yml' 
cannot be loaded: Source-Url is required in manifest to obtain cartridge via URL
```

(1) https://github.com/jboss-mobile/jboss-unified-push-openshift-cartridge/blob/master/metadata/manifest.yml#L11
